### PR TITLE
performance: move log group filters to invoker

### DIFF
--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -41,8 +41,6 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName
@@ -50,6 +48,21 @@ Resources:
           Value: "AxiomCloudWatchForwarder"
         - Key: "Platform"
           Value: "Axiom"
+  ForwarderPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - lambda:AddPermission
+              - lambda:RemovePermission
+            Effect: Allow
+            Resource: "*"
+      PolicyName: !Sub "${AWS::StackName}-forwarder-lambda-policy"
+      Roles:
+        - !Ref "ForwarderRole"
   ForwarderLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cloudformation-stacks/listener.template.yaml
+++ b/cloudformation-stacks/listener.template.yaml
@@ -110,6 +110,8 @@ Resources:
               - logs:DescribeSubscriptionFilters
               - logs:FilterLogEvents
               - logs:GetLogEvents
+              - logs:CreateLogStream
+              - logs:PutLogEvents
             Effect: Allow
             Resource: "*"
       PolicyName: axiom-cloudwatch-listener-policy
@@ -127,8 +129,6 @@ Resources:
               Service:
                 - lambda.amazonaws.com
                 - logs.amazonaws.com
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   ListenerLambda:
     Type: AWS::Lambda::Function
     DependsOn:
@@ -140,7 +140,7 @@ Resources:
       Code:
         ZipFile: |
           # DO NOT EDIT
-          # CI will replace these comments with the code from ./logs_subscriber.py
+          # CI will replace these comments with the code from ./listener.py
       Role: !GetAtt
         - ListenerRole
         - Arn

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -41,15 +41,17 @@ Resources:
       PolicyDocument:
         Statement:
           - Action:
+              - logs:DescribeSubscriptionFilters
               - logs:DeleteSubscriptionFilter
               - logs:PutSubscriptionFilter
               - logs:DescribeLogGroups
-              - logs:DescribeSubscriptionFilters
+              - logs:CreateLogStream
+              - logs:PutLogEvents
               - lambda:AddPermission
               - lambda:RemovePermission
             Effect: Allow
             Resource: "*"
-      PolicyName: axiom-cloudwatch-subscriber-lambda-policy
+      PolicyName: !Sub "${AWS::StackName}-subscriber-lambda-policy"
       Roles:
         - !Ref "SubscriberRole"
   SubscriberLogGroup:
@@ -76,8 +78,6 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   SubscriberLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -18,18 +18,22 @@ Parameters:
     Type: String
     Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to ship logs to Axiom.
     AllowedPattern: ".+" # required
-  CloudWatchLogGroupsNames:
+  CloudWatchLogGroupNames:
     Type: String
     Description: A comma separated list of CloudWatch log groups to subscribe to.
     Default: "" # all
-  CloudWatchLogGroupsPrefix:
+  CloudWatchLogGroupPrefix:
     Type: String
     Description: The Prefix of CloudWatch log groups to subscribe to.
     Default: "" # all
-  CloudWatchLogGroupsPattern:
+  CloudWatchLogGroupPattern:
     Type: String
     Description: A regular expression pattern of CloudWatch log groups to subscribe to.
     Default: "" # all
+  ForceUpdate:
+    Type: String
+    Description: Enter a random string to force an update of the stack.
+    Default: ""
 Resources:
   SubscriberPolicy:
     Type: AWS::IAM::Policy
@@ -102,9 +106,6 @@ Resources:
       Environment:
         Variables:
           AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref "AxiomCloudWatchForwarderLambdaARN"
-          LOG_GROUP_NAMES: !Ref "CloudWatchLogGroupsNames"
-          LOG_GROUP_PREFIX: !Ref "CloudWatchLogGroupsPrefix"
-          LOG_GROUP_PATTERN: !Ref "CloudWatchLogGroupsPattern"
   SubscriberInvoker:
     Type: AWS::CloudFormation::CustomResource
     DependsOn: SubscriberLambda
@@ -112,3 +113,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt SubscriberLambda.Arn
       StackName: !Ref AWS::StackName
+      Force: !Ref "ForceUpdate"
+      CloudWatchLogGroupNames: !Ref "CloudWatchLogGroupNames"
+      CloudWatchLogGroupPrefix: !Ref "CloudWatchLogGroupPrefix"
+      CloudWatchLogGroupPattern: !Ref "CloudWatchLogGroupPattern"

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -3,10 +3,6 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: "Forwarder lambda"
-        Parameters:
-          - AxiomCloudWatchForwarderLambdaARN
-      - Label:
           default: "Log groups to unsubscribe from"
         Parameters:
           - CloudWatchLogGroupsNames
@@ -14,10 +10,6 @@ Metadata:
           - CloudWatchLogGroupsPattern
 
 Parameters:
-  AxiomCloudWatchForwarderLambdaARN:
-    Type: String
-    Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to forward logs to Axiom.
-    AllowedPattern: ".+" # required
   CloudWatchLogGroupNames:
     Type: String
     Description: A comma-separated list of CloudWatch log groups to unsubscribe from.
@@ -101,9 +93,6 @@ Resources:
           Value: "AxiomCloudWatchUnsubscriber"
         - Key: "Platform"
           Value: "Axiom"
-      Environment:
-        Variables:
-          AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref "AxiomCloudWatchForwarderLambdaARN"
   UnsubscriberInvoker:
     Type: AWS::CloudFormation::CustomResource
     DependsOn: UnsubscriberLambda

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -103,9 +103,6 @@ Resources:
       Environment:
         Variables:
           AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref "AxiomCloudWatchForwarderLambdaARN"
-          LOG_GROUP_NAMES: !Ref "CloudWatchLogGroupsNames"
-          LOG_GROUP_PREFIX: !Ref "CloudWatchLogGroupsPrefix"
-          LOG_GROUP_PATTERN: !Ref "CloudWatchLogGroupsPattern"
   UnsubscriberInvoker:
     Type: AWS::CloudFormation::CustomResource
     DependsOn: UnsubscriberLambda

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -41,14 +41,17 @@ Resources:
       PolicyDocument:
         Statement:
           - Action:
+              - logs:DescribeSubscriptionFilters
               - logs:DeleteSubscriptionFilter
               - logs:PutSubscriptionFilter
               - logs:DescribeLogGroups
+              - logs:CreateLogStream
+              - logs:PutLogEvents
               - lambda:AddPermission
               - lambda:RemovePermission
             Effect: Allow
             Resource: "*"
-      PolicyName: axiom-cloudwatch-unsubscriber-lambda-policy
+      PolicyName: !Sub "${AWS::StackName}-unsubscriber-lambda-policy"
       Roles:
         - !Ref "UnsubscriberRole"
   UnsubscriberLogGroup:
@@ -75,8 +78,6 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   UnsubscriberLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -18,18 +18,22 @@ Parameters:
     Type: String
     Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to forward logs to Axiom.
     AllowedPattern: ".+" # required
-  CloudWatchLogGroupsNames:
+  CloudWatchLogGroupNames:
     Type: String
     Description: A comma-separated list of CloudWatch log groups to unsubscribe from.
     Default: "" # all
-  CloudWatchLogGroupsPrefix:
+  CloudWatchLogGroupPrefix:
     Type: String
     Description: The prefix of CloudWatch log groups to unsubscribe from.
     Default: "" # all
-  CloudWatchLogGroupsPattern:
+  CloudWatchLogGroupPattern:
     Type: String
     Description: A regular expression pattern for CloudWatch log groups to unsubscribe from.
     Default: "" # all
+  ForceUpdate:
+    Type: String
+    Description: Enter a random string to force an update of the stack.
+    Default: ""
 Resources:
   UnsubscriberPolicy:
     Type: AWS::IAM::Policy
@@ -109,3 +113,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt UnsubscriberLambda.Arn
       StackName: !Ref AWS::StackName
+      Force: !Ref "ForceUpdate"
+      CloudWatchLogGroupNames: !Ref "CloudWatchLogGroupNames"
+      CloudWatchLogGroupPrefix: !Ref "CloudWatchLogGroupPrefix"
+      CloudWatchLogGroupPattern: !Ref "CloudWatchLogGroupPattern"

--- a/forwarder.py
+++ b/forwarder.py
@@ -78,6 +78,7 @@ def push_events_to_axiom(events: list):
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {axiom_token}",
+            "User-Agent": "axiom-cloudwatch-forwarder/v1.1.0",
         },
     )
 

--- a/subscriber.py
+++ b/subscriber.py
@@ -17,9 +17,7 @@ lambda_client = boto3.client("lambda")
 axiom_cloudwatch_forwarder_lambda_arn = os.getenv(
     "AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN"
 )
-log_group_names = os.getenv("LOG_GROUP_NAMES", None)
-log_group_prefix = os.getenv("LOG_GROUP_PREFIX", None)
-log_group_pattern = os.getenv("LOG_GROUP_PATTERN", None)
+
 log_groups_return_limit = 50
 
 
@@ -96,6 +94,10 @@ def lambda_handler(event: dict, context=None):
             event, context, cfnresponse.SUCCESS, {}, event["PhysicalResourceId"]
         )
         return
+
+    log_group_names = event["ResourceProperties"]["CloudWatchLogGroupNames"]
+    log_group_prefix = event["ResourceProperties"]["CloudWatchLogGroupPrefix"]
+    log_group_pattern = event["ResourceProperties"]["CloudWatchLogGroupPattern"]
 
     if (
         axiom_cloudwatch_forwarder_lambda_arn is None

--- a/unsubscriber.py
+++ b/unsubscriber.py
@@ -17,9 +17,6 @@ lambda_client = boto3.client("lambda")
 axiom_cloudwatch_forwarder_lambda_arn = os.getenv(
     "AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN"
 )
-log_group_names = os.getenv("LOG_GROUP_NAMES", None)
-log_group_prefix = os.getenv("LOG_GROUP_PREFIX", None)
-log_group_pattern = os.getenv("LOG_GROUP_PATTERN", None)
 log_groups_return_limit = 50
 
 
@@ -91,6 +88,10 @@ def lambda_handler(event: dict, context=None):
         }
         cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
         return
+
+    log_group_names = event["ResourceProperties"]["CloudWatchLogGroupNames"]
+    log_group_prefix = event["ResourceProperties"]["CloudWatchLogGroupPrefix"]
+    log_group_pattern = event["ResourceProperties"]["CloudWatchLogGroupPattern"]
 
     forwarder_lambda_group_name = (
         "/aws/lambda/" + axiom_cloudwatch_forwarder_lambda_arn.split(":")[-1]

--- a/unsubscriber.py
+++ b/unsubscriber.py
@@ -14,9 +14,6 @@ logger.setLevel(level)
 cloudwatch_logs_client = boto3.client("logs")
 lambda_client = boto3.client("lambda")
 
-axiom_cloudwatch_forwarder_lambda_arn = os.getenv(
-    "AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN"
-)
 log_groups_return_limit = 50
 
 
@@ -78,24 +75,9 @@ def delete_subscription_filter(log_group_name: str):
 
 
 def lambda_handler(event: dict, context=None):
-    if (
-        axiom_cloudwatch_forwarder_lambda_arn is None
-        or axiom_cloudwatch_forwarder_lambda_arn == ""
-    ):
-        responseData = {
-            "success": False,
-            "body": "AXIOM_CLOUDWATCH_LAMBDA_FORWARDER_ARN is not set",
-        }
-        cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
-        return
-
     log_group_names = event["ResourceProperties"]["CloudWatchLogGroupNames"]
     log_group_prefix = event["ResourceProperties"]["CloudWatchLogGroupPrefix"]
     log_group_pattern = event["ResourceProperties"]["CloudWatchLogGroupPattern"]
-
-    forwarder_lambda_group_name = (
-        "/aws/lambda/" + axiom_cloudwatch_forwarder_lambda_arn.split(":")[-1]
-    )
 
     log_group_names_list = (
         log_group_names.split(",") if log_group_names is not None else []
@@ -114,10 +96,6 @@ def lambda_handler(event: dict, context=None):
 
     responseData = {}
     for group in log_groups:
-        # skip the Forwarder lambda log group to avoid circular logging
-        if group["name"] == forwarder_lambda_group_name:
-            continue
-
         report["matched_log_groups"].append(group["name"])
         report["errors"][group["name"]] = []
 


### PR DESCRIPTION
Moved the env variables to invoker, and used the ResourceProperties instead to get these values. This avoids modifying the Lambda environment variables, which used to force a Lambda function update by CloudFormation and prolongs the whole process.

context:

> Another thing, just as a suggestion from a performance perspective: it might be beneficial to provide  CloudWatchLogGroupsNames, CloudWatchLogGroupsPrefix, and CloudWatchLogGroupsPattern to the Custom Resource instead of passing them to Lambda function as environment variables. CloudFormation includes the Custom Resource properties in the payload sent to Lambda, so you can read them from the event (from the ResourceProperties property) in the code. This avoids modifying the Lambda environment variables, which forces a Lambda function update by CloudFormation and prolongs the whole process.


This PR also changes the parameters to remove the `s` in `Groups` to be consistent, e.g: `CloudWatchLogGroupNames` instead of `CloudWatchLogGroupsNames`