### PR TITLE
Fix incorrect IAM role reference in Listener CloudFormation template

### DIFF
--- a/cloudformation-stacks/listener.template.yaml
+++ b/cloudformation-stacks/listener.template.yaml
@@ -53,7 +53,7 @@ Resources:
             Resource: "*"
       PolicyName: axiom-cloudwatch-listener-policy
       Roles:
-        - !Ref "ListenerLambda"
+        - !Ref "ListenerRole"
   ListenerRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
This PR resolves an issue in the Listener CloudFormation template where the `ListenerLambda` resource was incorrectly referenced under the `Roles` property of the `ListenerPolicy` resource. The incorrect reference has been updated to `ListenerRole`, ensuring proper association and functionality.

**Changes Made:**
- Updated the `Roles` property of `ListenerPolicy` in `cloudformation-stacks/listener.template.yaml` file.

**Impact of the Change:**
- The CloudFormation stack now deploys correctly without raising errors related to IAM role association that says:
`Resource handler returned message: "The role with name axiom-cloudwatch-listener cannot be found. `

**Testing:**
- Verified successful deployment in us-west-2 region and us-east-1 in my aws account after the fix.

Please review and merge this fix. Let me know if additional updates or testing is required.